### PR TITLE
Feature broken bottle weapon

### DIFF
--- a/Content/Items/BrokenBottle.cs
+++ b/Content/Items/BrokenBottle.cs
@@ -1,0 +1,27 @@
+using Terraria;
+using Terraria.ID;
+using Terraria.ModLoader;
+
+namespace TheGoodTheBadAndTheIntoxicated.Content.Items
+{ 
+	// This is a basic item template.
+	// Please see tModLoader's ExampleMod for every other example:
+	// https://github.com/tModLoader/tModLoader/tree/stable/ExampleMod
+	public class BrokenBottle : ModItem
+	{
+		// The Display Name and Tooltip of this item can be edited in the 'Localization/en-US_Mods.TheGoodTheBadAndTheIntoxicated.hjson' file.
+		public override void SetDefaults()
+		{
+			// Copy stats of lead shortsword
+            Item.CloneDefaults(ItemID.LeadShortsword);
+        }
+
+		public override void AddRecipes()
+		{
+			Recipe recipe = CreateRecipe();
+			recipe.AddIngredient(ItemID.DirtBlock, 10);
+			recipe.AddTile(TileID.WorkBenches);
+			recipe.Register();
+		}
+	}
+}

--- a/Localization/en-US_Mods.TheGoodTheBadAndTheIntoxicated.hjson
+++ b/Localization/en-US_Mods.TheGoodTheBadAndTheIntoxicated.hjson
@@ -34,6 +34,11 @@ Items: {
 		DisplayName: The Rattler
 		Tooltip: ""
 	}
+
+	BrokenBottle: {
+		DisplayName: Broken Bottle
+		Tooltip: ""
+	}
 }
 
 NPCs: {


### PR DESCRIPTION
## Summary
- Created the broken bottle weapon

## Imagery
<img width="360" height="275" alt="image" src="https://github.com/user-attachments/assets/1eee0bf4-c42c-4bae-820c-6d158a85801f" />


## Additional Tests
- Gather 10 dirt and craft it at a crafting station
- View weapon in inventory
- Use weapon on enemy

## Remaining Issues/Bugs
- When the weapon is used it shows the sprite of the lead shortsword instead of a broken bottle because the spritesheet is missing use animation sprites. The lead shortsword comes from it being used to inherit the defaults of the item, but when using manually put in values, there is no sprite displayed at all.