### PR TITLE
Added item prices for each weapon

### DIFF
--- a/Content/Items/BoltAction.cs
+++ b/Content/Items/BoltAction.cs
@@ -18,6 +18,7 @@ namespace TheGoodTheBadAndTheIntoxicated.Content.Items
             Item.height = 20; // Hitbox height of the item.
             Item.scale = 1f;
             Item.rare = ItemRarityID.Green; // The color that the item's name will be in-game.
+            Item.value = Item.sellPrice(0, 1, 50, 0);
 
             // Use Properties
             Item.useTime = 50; // The item's use time in ticks (60 ticks == 1 second.)

--- a/Content/Items/Bounty.cs
+++ b/Content/Items/Bounty.cs
@@ -22,7 +22,7 @@ namespace TheGoodTheBadAndTheIntoxicated.Content.Items
             Item.mana = 70; // 20 mana = 1 container
             Item.knockBack = 0.0f; // no knockback
             Item.rare = ItemRarityID.Orange;
-            Item.value = Item.buyPrice(silver: 50);
+            Item.value = Item.sellPrice(0, 7, 0, 0);
             Item.UseSound = SoundID.Item20; // magic sound
             Item.noMelee = true; // doesn't do melee damage
             Item.shoot = ModContent.ProjectileType<BountyProjectile>(); // shoots a custom bounty projectile

--- a/Content/Items/LeverAction.cs
+++ b/Content/Items/LeverAction.cs
@@ -18,6 +18,7 @@ namespace TheGoodTheBadAndTheIntoxicated.Content.Items
             Item.height = 24; // Hitbox height of the item.
             Item.scale = 1f;
             Item.rare = ItemRarityID.Green; // The color that the item's name will be in-game.
+            Item.value = Item.sellPrice(0, 1, 50, 0);
 
             // Use Properties
             Item.useTime = 45; // The item's use time in ticks (60 ticks == 1 second.)

--- a/Content/Items/SixShooter.cs
+++ b/Content/Items/SixShooter.cs
@@ -18,6 +18,7 @@ namespace TheGoodTheBadAndTheIntoxicated.Content.Items
             Item.height = 30; // Hitbox height of the item.
             Item.scale = 0.75f;
             Item.rare = ItemRarityID.Green; // The color that the item's name will be in-game.
+            Item.value = Item.sellPrice(0, 1, 50, 0);
 
             // Use Properties
             Item.useTime = 24; // The item's use time in ticks (60 ticks == 1 second.)

--- a/Content/Items/TheRattler.cs
+++ b/Content/Items/TheRattler.cs
@@ -18,6 +18,7 @@ namespace TheGoodTheBadAndTheIntoxicated.Content.Items
             Item.height = 20; // Hitbox height of the item.
             Item.scale = 1f;
             Item.rare = ItemRarityID.LightRed; // The color that the item's name will be in-game.
+            Item.value = Item.sellPrice(0, 2, 0, 0); // This is the same value as the Bee Keeper, a Queen Bee weapon drop
 
             // Use Properties
             Item.useTime = 60; // The item's use time in ticks (60 ticks == 1 second.)


### PR DESCRIPTION
## Summary
<!--- Give a brief verbal summary of what is included in this PR. --->
- Added item prices to all the weapons that didn't have them
- Adjusted some item prices that were already added to balance better

## Additional Tests
<!--- Describe any tests that should be run --->
- Open shop and hover over our items in your inventory to see their price
- If gunslinger is showing expanded inventory, (temporarily after eye of cthulhu is defeated) check the prices of our items in his shop
